### PR TITLE
Add link to IPFS Community WG Roadmap - DUPLICATE of #8

### DIFF
--- a/WG_COMMUNITY.md
+++ b/WG_COMMUNITY.md
@@ -1,0 +1,1 @@
+Please see the [IPFS Community Working Group Roadmap](https://github.com/ipfs/community/blob/master/ROADMAP.md). 


### PR DESCRIPTION
Add link to IPFS Community WG Roadmap in the `community` repo.