### PR TITLE
docs: (de-scoping) first pass at updating the JS Core Roadmap

### DIFF
--- a/WG_JS_CORE.md
+++ b/WG_JS_CORE.md
@@ -11,28 +11,30 @@
 **Current Projects**
 - JS IPFS
 - JS IPFS API
-- Go & JS IPFS Interop
-- Npm on IPFS
+- [Go & JS IPFS Interop Test Suite](http://github.com/ipfs/interop)
+- NPM on IPFS
 - IPFS Service Worker Gateway
 - IPFS Geo IP
-- IPFS Performance Profiling
-- benchmark-js.ipfs.io
+- [IPFS Performance Profiling](http://github.com/ipfs/ipfs-performance-profiling)
+- https://benchmark-js.ipfs.io
+- https://js.ipfs.io
+- https://benchmarks.ipfs.team/
 
 
 ## 🚀 Major 2019 Goals to achieve
 
 The major goals below and following milestones have been labeled with the emoji for the goal in the IPFS Project Roadmap that they contribute towards:
  
-📦 = Package Managers  🗂 = Large Files  🔄 = Decentralized Web  🤝 = Partner Use Cases  🧠 = Strategic Projects
+📦 = Package Managers  🤝 = Partner Use Cases
  
-- JS IPFS is ready for use in production. It is stable, performant, and interoperable with other IPFS implementations 📦 🗂 🔄 🤝 🧠
-- JS IPFS can ingest and move data with similar speeds to rsync or wget 📦 🗂 🔄 🤝
-- Data on JS IPFS is searchable both online and offline 📦 🔄 🤝
-- Developer experience is a joy  🔄 🤝 🧠
+- JS IPFS is ready for use in production. It is stable, performant, and interoperable with other IPFS implementations 📦 🤝
+- JS IPFS can ingest and move data with similar speeds to rsync or wget 📦 🤝
+- Data on JS IPFS is searchable both online and offline 📦 🤝
+- Developer experience is a joy 🤝
 
 ## 💎 Milestones
 
-### `M (P0)`: Production ready 📦 🗂 🔄 🤝 🧠
+### `M (P0)`: Production ready 📦 🤝
 
 JS IPFS has for a long time now been under heavy development with a focus on implementing features. We’re now at a stage where it has a good level of feature parity to Go IPFS. Implementing the last key missing features and focused attention on performance, stability and security issues will allow JS IPFS to be a viable alternative to Go IPFS.
 
@@ -50,7 +52,7 @@ JS IPFS has for a long time now been under heavy development with a focus on imp
 - An IPFS log API is implemented and tests ensure log messages are part of the API
 - A security audit is conducted on the code base and all issues resolved
 
-### `M (P1)`: Optimized for browser environments 🔄 🤝 🧠
+### `M (P1)`: Optimized for browser environments 📦 🤝
 
 One of the biggest challenges that faces JS IPFS is that it will be used in many different environments where the tools and resources available to it differ significantly. JS IPFS can be run in a browser (Chrome, Firefox etc.), in a web extension, in Node.js on a laptop or on a server, in Electron, on mobile or even on IoT devices. Not only does the runtime differ - Node.js, Blink, SpiderMonkey etc. but the APIs available (no filesystem or low level network in a browser) as well as the hardware resources available e.g. mobile or IoT.
 
@@ -67,7 +69,7 @@ One of the biggest challenges that faces JS IPFS is that it will be used in many
 - A JS IPFS daemon can run on a Raspberry Pi for at least 1 month
 - Example projects exist for running JS IPFS in a web view on iOS and Android
 
-### `M (P1)`: Installable npm modules via JS IPFS 📦 🗂 🔄 🧠
+### `M (P1)`: Installable npm modules via JS IPFS 📦
 
 The npm registry is one of the biggest data sets JS developers interact with daily. There’s a myriad of benefits to it being accessible on the IPFS network. We’ll enable this at the same time as proving out the ability for JS IPFS to deal with large data sets.
 
@@ -78,7 +80,7 @@ The npm registry is one of the biggest data sets JS developers interact with dai
 - Installing any module is faster than using npm when 5 peers on the local network already have the package
 Node.js binaries are distributed via IPFS (making the whole Node.js/NPM installation process happen over IPFS)
  
-### `M (P2)`: Discoverable npm modules via JS IPFS 📦 🗂 🔄 🧠
+### `M (P2)`: Discoverable npm modules via JS IPFS 📦
 
 One of the big features that IPFS lacks right now is content discoverability. A mechanism of searching for content on the IPFS network would greatly improve the situation. Considering our milestone of installing npm modules via JS IPFS, it makes sense to augment it with a search component to make it more attractive and useful as well as allowing us to achieve our major goal of adding search to JS IPFS.
  
@@ -86,7 +88,7 @@ One of the big features that IPFS lacks right now is content discoverability. A 
 - Users can learn about the latest registry index (module updates) via IPFS
 - Unixfs v2 is finalized and is the default format for new content added to IPFS
 
-### `M (P2)`: Improved documentation, specs and examples 🔄 🤝 🧠
+### `M (P2)`: Improved documentation, specs and examples 🤝
 
 Improving the docs, specs and having great tutorials and examples goes a long way to realising the distributed web for the simple reason that if people can’t drop by and pick up IPFS easily they’re less likely to use it. This milestone addresses that problem and also helps people already invested in IPFS to continue to build on top of it.
 
@@ -97,7 +99,7 @@ Improving the docs, specs and having great tutorials and examples goes a long wa
   - Return values are documented, including object properties and types
 - Onboarding documentation exists to explain domain concepts and provide tutorials/examples for achieving common tasks
 
-### `M (P0)`: Revamped APIs 🔄 🤝 🧠
+### `M (P0)`: Revamped APIs 📦 🤝
 
 Revamping the APIs will make them easier to use and simpler to understand. Using modern syntax will make JS IPFS appealing to a wider segment of the JS community, aiding adoption and contributions. It also gives us scope to make performance optimisations and stability/debuggability improvements.
 
@@ -111,11 +113,11 @@ Revamping the APIs will make them easier to use and simpler to understand. Using
 - Old APIs are deprecated and removed (e.g. object, block)
 - At least one alternative API exists for JS IPFS (e.g. Graphql)
 
-### `M (P3)`: Support for specific use cases 🔄 🤝 🧠
+### `M (P3)`: Increased support for Package Managers, specifically 📦 🤝
 
-This milestone focuses in on how JS IPFS can refine and augment it’s existing tech stack to better serve specific use cases.
+This milestone focuses in on how JS IPFS can refine and augment it’s existing tech stack to better serve the Package Managers Usecase use cases.
 
-- Default chunkers exist for particular file types to optimise for example deduplication or seeking/direct access in tar archives and video files
+- Default chunkers exist for particular file types to optimise for example deduplication or seeking/direct access in tar archives
 - High priority features requested from other working groups that have experienced pain points with the JS IPFS API are implemented e.g. Pagination and “Live” streams
 - IPFS nodes can discover one another for specific topics via the rendezvous protocol
 -star servers are no longer in use
@@ -124,7 +126,12 @@ This milestone focuses in on how JS IPFS can refine and augment it’s existing 
 
 ## Timeline
 
-- Q1
-- Q2
-- Q3
-- Q4
+`TODO`
+
+### Q1
+
+### Q2
+
+### Q3
+
+### Q4

--- a/WG_JS_CORE.md
+++ b/WG_JS_CORE.md
@@ -1,7 +1,7 @@
 # JS Core Dev Team 2019 Roadmap
 
 > Oversees the development of the JS implementation of the IPFS protocol and related projects.
- 
+
 **Responsibilities include:**
 - Implement and maintain the IPFS protocol and tools
 - Enable IPFS usage in Node.js, browsers and other JavaScript runtimes
@@ -9,24 +9,24 @@
 - Incubate and grow projects that will encourage IPFS adoption
 
 **Current Projects**
-- JS IPFS
-- JS IPFS API
+- [JS IPFS](https://github.com/ipfs/js-ipfs)
+- [JS IPFS HTTP Client](https://github.com/ipfs/js-ipfs-http-client)
 - [Go & JS IPFS Interop Test Suite](http://github.com/ipfs/interop)
-- NPM on IPFS
-- IPFS Service Worker Gateway
-- IPFS Geo IP
+- [NPM on IPFS](https://github.com/ipfs-shipyard/npm-on-ipfs)
+- [IPFS Service Worker Gateway](https://github.com/ipfs-shipyard/service-worker-gateway)
+- [IPFS Geo IP](https://github.com/ipfs/ipfs-geoip)
 - [IPFS Performance Profiling](http://github.com/ipfs/ipfs-performance-profiling)
 - https://benchmark-js.ipfs.io
 - https://js.ipfs.io
-- https://benchmarks.ipfs.team/
+- https://benchmarks.ipfs.team
 
 
 ## 🚀 Major 2019 Goals to achieve
 
 The major goals below and following milestones have been labeled with the emoji for the goal in the IPFS Project Roadmap that they contribute towards:
- 
+
 📦 = Package Managers  🤝 = Partner Use Cases
- 
+
 - JS IPFS is ready for use in production. It is stable, performant, and interoperable with other IPFS implementations 📦 🤝
 - JS IPFS can ingest and move data with similar speeds to rsync or wget 📦 🤝
 - Data on JS IPFS is searchable both online and offline 📦 🤝
@@ -40,14 +40,17 @@ JS IPFS has for a long time now been under heavy development with a focus on imp
 
 - A JS IPFS daemon runs as part of the IPFS gateway cluster for at least 1 month without crashing
 - Performance metrics for a JS IPFS node are measurable:
-- Tools can process and graph performance data
-- Data can be queried to track down bugs and performance bottlenecks
+    - Tools can process and graph performance data
+    - Data can be queried to track down bugs and performance bottlenecks
 - Benchmarks exist to assert that:
   - Memory footprint remains stable and should not consume more than 20% more memory than a Go IPFS node
   - Network throughput is within an acceptable magnitude of Go IPFS
   - Data can be fetched with comparable speeds to tools like bittorrent, wget or rsync when 5 peers are connected who already have the data
   - Data can be exchanged with another IPFS node within 2x the speed a Go IPFS node would exchange it
 - An interoperable DHT exists and scales to hundreds of thousands of nodes
+- JS IPFS nodes can discover one another for specific topics via the rendezvous protocol
+    - \*-star servers are no longer in use
+- JS IPFS nodes use, and are compliant with the MDNS spec
 - A gossipsub implementation exists
 - An IPFS log API is implemented and tests ensure log messages are part of the API
 - A security audit is conducted on the code base and all issues resolved
@@ -56,18 +59,12 @@ JS IPFS has for a long time now been under heavy development with a focus on imp
 
 One of the biggest challenges that faces JS IPFS is that it will be used in many different environments where the tools and resources available to it differ significantly. JS IPFS can be run in a browser (Chrome, Firefox etc.), in a web extension, in Node.js on a laptop or on a server, in Electron, on mobile or even on IoT devices. Not only does the runtime differ - Node.js, Blink, SpiderMonkey etc. but the APIs available (no filesystem or low level network in a browser) as well as the hardware resources available e.g. mobile or IoT.
 
-- Default performance profiles exist and can be enabled to adapt IPFS behaviour appropriately to its environment. In addition to the profiles described here, the following profiles also exist:
-  - Browser
-  - Electron
-  - Mobile
-  - IoT
+- Default performance profiles exist and can be enabled to adapt IPFS behaviour appropriately to its environment. In addition to the profiles [described here](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#profiles), we'll also add a browser specific performance profile.
 - The JS IPFS build can be customised to exclude functionality or include different modules that are more appropriate for a particular runtime environment
 - At least 2 recommended builds for common environments will be provided in addition to the full build
 - Developers can tailor an IPFS build to their specific needs
 - Full build bundle size is monitored and does not exceed 2MB (minified)
 - Examples for bundling JS IPFS with common tools such as webpack/parcel exist
-- A JS IPFS daemon can run on a Raspberry Pi for at least 1 month
-- Example projects exist for running JS IPFS in a web view on iOS and Android
 
 ### `M (P1)`: Installable npm modules via JS IPFS 📦
 
@@ -79,11 +76,12 @@ The npm registry is one of the biggest data sets JS developers interact with dai
 - Installing npm modules over LAN never fails (provided the module is available on another IPFS node connected to the LAN)
 - Installing any module is faster than using npm when 5 peers on the local network already have the package
 Node.js binaries are distributed via IPFS (making the whole Node.js/NPM installation process happen over IPFS)
- 
+- Default chunkers exist for particular file types to optimise for example deduplication or seeking/direct access in tar archives
+
 ### `M (P2)`: Discoverable npm modules via JS IPFS 📦
 
 One of the big features that IPFS lacks right now is content discoverability. A mechanism of searching for content on the IPFS network would greatly improve the situation. Considering our milestone of installing npm modules via JS IPFS, it makes sense to augment it with a search component to make it more attractive and useful as well as allowing us to achieve our major goal of adding search to JS IPFS.
- 
+
 - Users can search for modules in the npm registry via IPFS
 - Users can learn about the latest registry index (module updates) via IPFS
 - Unixfs v2 is finalized and is the default format for new content added to IPFS
@@ -115,14 +113,9 @@ Revamping the APIs will make them easier to use and simpler to understand. Using
 
 ### `M (P3)`: Increased support for Package Managers, specifically 📦 🤝
 
-This milestone focuses in on how JS IPFS can refine and augment it’s existing tech stack to better serve the Package Managers Usecase use cases.
+This milestone focuses in on how JS IPFS can refine and augment its existing tech stack to better serve the Package Managers use case.
 
-- Default chunkers exist for particular file types to optimise for example deduplication or seeking/direct access in tar archives
 - High priority features requested from other working groups that have experienced pain points with the JS IPFS API are implemented e.g. Pagination and “Live” streams
-- IPFS nodes can discover one another for specific topics via the rendezvous protocol
--star servers are no longer in use
-- IPFS nodes work and are compliant with the MDNS spec
-- Libp2p discovery and transport modules exist for bluetooth and libdweb, sound and potentially other exotic technologies
 
 ## Timeline
 

--- a/WG_JS_CORE.md
+++ b/WG_JS_CORE.md
@@ -76,7 +76,6 @@ The npm registry is one of the biggest data sets JS developers interact with dai
 - Installing npm modules over LAN never fails (provided the module is available on another IPFS node connected to the LAN)
 - Installing any module is faster than using npm when 5 peers on the local network already have the package
 Node.js binaries are distributed via IPFS (making the whole Node.js/NPM installation process happen over IPFS)
-- Default chunkers exist for particular file types to optimise for example deduplication or seeking/direct access in tar archives
 
 ### `M (P2)`: Discoverable npm modules via JS IPFS 📦
 

--- a/WG_JS_CORE.md
+++ b/WG_JS_CORE.md
@@ -166,8 +166,7 @@ N.B. Some big goals span multiple quarters and so are listed multiple times.
     - Developers can tailor an IPFS build to their specific needs
     - Examples for bundling JS IPFS with common tools such as webpack/parcel exist
 * `M (P2)`: Discoverable npm modules via JS IPFS (Part 1)
-    - Users can search for modules in the npm registry via IPFS
-    - Users can learn about the latest registry index (module updates) via IPFS
+    - Unixfs v2 is finalized and is the default format for new content added to IPFS
 
 ### Q4
 * `M (P0)`: Production ready (Part 4)
@@ -184,4 +183,5 @@ N.B. Some big goals span multiple quarters and so are listed multiple times.
       - Return values are documented, including object properties and types
     - Onboarding documentation exists to explain domain concepts and provide tutorials/examples for achieving common tasks
 * `M (P2)`: Discoverable npm modules via JS IPFS (Part 2)
-    - Unixfs v2 is finalized and is the default format for new content added to IPFS
+    - Users can search for modules in the npm registry via IPFS
+    - Users can learn about the latest registry index (module updates) via IPFS

--- a/WG_JS_CORE.md
+++ b/WG_JS_CORE.md
@@ -112,12 +112,76 @@ Revamping the APIs will make them easier to use and simpler to understand. Using
 
 ## Timeline
 
-`TODO`
+N.B. Some big goals span multiple quarters and so are listed multiple times.
 
 ### Q1
+* `M (P0)`: Revamped APIs (Part 1)
+    - Async/await is used throughout the codebase and callback APIs are dropped
+    - Streaming APIs switch to using async iterators/iterables
+* `M (P0)`: Production ready (Part 1)
+    - A JS IPFS daemon runs as part of the IPFS gateway cluster for at least 1 month without crashing
+    - Performance metrics for a JS IPFS node are measurable:
+        - Tools can process and graph performance data
+        - Data can be queried to track down bugs and performance bottlenecks
+    - An interoperable DHT exists and scales to hundreds of thousands of nodes
+* `M (P1)`: Installable npm modules via JS IPFS (Part 1)
+    - There is an option to select IPFS as a transport on npm/yarn
+    - A CLI tool exists to install packages directly from IPFS
+    - JS IPFS can ingest the entire npm registry
 
 ### Q2
+* `M (P0)`: Production ready (Part 2)
+    - A JS IPFS daemon runs as part of the IPFS gateway cluster for at least 1 month without crashing
+    - JS IPFS nodes can discover one another for specific topics via the rendezvous protocol
+        - \*-star servers are no longer in use
+    - A gossipsub implementation exists
+    - Benchmarks exist to assert that:
+        - Memory footprint remains stable and should not consume more than 20% more memory than a Go IPFS node
+        - Network throughput is within an acceptable magnitude of Go IPFS
+        - Data can be fetched with comparable speeds to tools like bittorrent, wget or rsync when 5 peers are connected who already have the data
+        - Data can be exchanged with another IPFS node within 2x the speed a Go IPFS node would exchange it
+* `M (P1)`: Optimized for browser environments (Part 1)
+    - Default performance profiles exist and can be enabled to adapt IPFS behaviour appropriately to its environment. In addition to the profiles [described here](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#profiles), there will be a browser specific performance profile.
+    - Full build bundle size is monitored and does not exceed 2MB (minified)
+* `M (P0)`: Revamped APIs (Part 2)
+    - Async/await is used throughout the codebase and callback APIs are dropped
+    - Streaming APIs switch to using async iterators/iterables
+* `M (P1)`: Installable npm modules via JS IPFS (Part 2)
+    - Installing npm modules over LAN never fails (provided the module is available on another IPFS node connected to the LAN)
+    - Installing any module is faster than using npm when 5 peers on the local network already have the package
+    Node.js binaries are distributed via IPFS (making the whole Node.js/NPM installation process happen over IPFS)
 
 ### Q3
+* `M (P0)`: Revamped APIs (Part 3)
+    - The files API is revamped:
+        - Files functions moved to the root namespace
+        - Non-MFS and MFS functions are merged
+        - A revamped RESTful HTTP API exists
+* `M (P0)`: Production ready (Part 3)
+    - JS IPFS nodes use, and are compliant with the MDNS spec
+    - An IPFS log API is implemented and tests ensure log messages are part of the API
+* `M (P1)`: Optimized for browser environments (Part 2)
+    - The JS IPFS build can be customised to exclude functionality or include different modules that are more appropriate for a particular runtime environment
+    - At least 2 recommended builds for common environments will be provided in addition to the full build
+    - Developers can tailor an IPFS build to their specific needs
+    - Examples for bundling JS IPFS with common tools such as webpack/parcel exist
+* `M (P2)`: Discoverable npm modules via JS IPFS (Part 1)
+    - Users can search for modules in the npm registry via IPFS
+    - Users can learn about the latest registry index (module updates) via IPFS
 
 ### Q4
+* `M (P0)`: Production ready (Part 4)
+    - A security audit is conducted on the code base and all issues resolved
+* `M (P0)`: Revamped APIs (Part 4)
+    - Old APIs are deprecated and removed (e.g. object, block)
+    - ArrayBuffer is supported as an alternative to Buffer input argument
+    - High priority features requested from other working groups that have experienced pain points with the JS IPFS API are implemented e.g. Pagination and “Live” streams
+* `M (P2)`: Improved documentation, specs and examples
+    - Code level:
+      - Functions/methods all have meaningful descriptions
+      - Functions/methods all have inline examples
+      - Parameters are all documented, including types and defaults
+      - Return values are documented, including object properties and types
+    - Onboarding documentation exists to explain domain concepts and provide tutorials/examples for achieving common tasks
+* `M (P2)`: Discoverable npm modules via JS IPFS (Part 2)
+    - Unixfs v2 is finalized and is the default format for new content added to IPFS

--- a/WG_JS_CORE.md
+++ b/WG_JS_CORE.md
@@ -59,7 +59,7 @@ JS IPFS has for a long time now been under heavy development with a focus on imp
 
 One of the biggest challenges that faces JS IPFS is that it will be used in many different environments where the tools and resources available to it differ significantly. JS IPFS can be run in a browser (Chrome, Firefox etc.), in a web extension, in Node.js on a laptop or on a server, in Electron, on mobile or even on IoT devices. Not only does the runtime differ - Node.js, Blink, SpiderMonkey etc. but the APIs available (no filesystem or low level network in a browser) as well as the hardware resources available e.g. mobile or IoT.
 
-- Default performance profiles exist and can be enabled to adapt IPFS behaviour appropriately to its environment. In addition to the profiles [described here](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#profiles), we'll also add a browser specific performance profile.
+- Default performance profiles exist and can be enabled to adapt IPFS behaviour appropriately to its environment. In addition to the profiles [described here](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#profiles), there will be a browser specific performance profile.
 - The JS IPFS build can be customised to exclude functionality or include different modules that are more appropriate for a particular runtime environment
 - At least 2 recommended builds for common environments will be provided in addition to the full build
 - Developers can tailor an IPFS build to their specific needs
@@ -102,19 +102,13 @@ Improving the docs, specs and having great tutorials and examples goes a long wa
 Revamping the APIs will make them easier to use and simpler to understand. Using modern syntax will make JS IPFS appealing to a wider segment of the JS community, aiding adoption and contributions. It also gives us scope to make performance optimisations and stability/debuggability improvements.
 
 - Async/await is used throughout the codebase and callback APIs are dropped
-- Support ArrayBuffer as an alternative to Buffer input argument
+- ArrayBuffer is supported as an alternative to Buffer input argument
 - Streaming APIs switch to using async iterators/iterables
 - The files API is revamped:
     - Files functions moved to the root namespace
     - Non-MFS and MFS functions are merged
     - A revamped RESTful HTTP API exists
 - Old APIs are deprecated and removed (e.g. object, block)
-- At least one alternative API exists for JS IPFS (e.g. Graphql)
-
-### `M (P3)`: Increased support for Package Managers, specifically 📦 🤝
-
-This milestone focuses in on how JS IPFS can refine and augment its existing tech stack to better serve the Package Managers use case.
-
 - High priority features requested from other working groups that have experienced pain points with the JS IPFS API are implemented e.g. Pagination and “Live” streams
 
 ## Timeline


### PR DESCRIPTION
Following https://github.com/ipfs/roadmap/pull/21, this is my first pass/suggestions. @alanshaw, @achingbrain please review.